### PR TITLE
fix: update crypto provider with fix for verification of hash

### DIFF
--- a/Azure.Developer.TrustedSigning.NotationPlugin/Azure.Developer.TrustedSigning.NotationPlugin.csproj
+++ b/Azure.Developer.TrustedSigning.NotationPlugin/Azure.Developer.TrustedSigning.NotationPlugin.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Developer.TrustedSigning.CryptoProvider" Version="0.1.43" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Developer.TrustedSigning.CryptoProvider" Version="0.1.46" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR solves #13. To do so it needs to update the crypto provider with a fix that ensures proper validation of our signing certificates on the linux/macOS environment. This was a regression bug introduced on version 1.0.26 of the crypto provider package.

We also added proper validation on the internal crypto provider feed to ensure we test again linux prior to merging. I'm hoping we can proceed with moving this repository to github.