### PR TITLE
feat: add nuget.config 

### DIFF
--- a/Azure.Developer.ArtifactSigning.NotationPlugin.sln
+++ b/Azure.Developer.ArtifactSigning.NotationPlugin.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		Directory.Packages.props = Directory.Packages.props
 		LICENSE = LICENSE
+		NuGet.Config = NuGet.Config
 		README.md = README.md
 		SECURITY.md = SECURITY.md
 	EndProjectSection

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <activePackageSource>
+  </activePackageSource>
+  <packageSources>
+    <clear />
+    <add key="Nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR adds a nuget.config to the root of the repository, and also a reference to the solution file. We'll use the default nuget.org, but its flexible enough to be swapped to any feed.