### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# For more details on the syntax of this file,
+# see https://help.github.com/articles/about-codeowners
+
+# Default owner
+* @azure/artifact-signing-team


### PR DESCRIPTION
This PR adds the artifact-signing team as codeowners for this repository